### PR TITLE
Improve UX: overlay badges, mobile responsiveness, accessibility, retry logic

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -26,7 +26,7 @@
   --trend-strong-decrease: #ff1744;
 
   /* Alert colors */
-  --alert-critical: #ff1744;
+  --alert-critical: #ff4757;
   --alert-warning: #ffab40;
   --alert-watch: #60a5fa;
 
@@ -56,7 +56,7 @@
   --transition-slow: 400ms ease-out;
 
   /* Critical blink */
-  --critical-blink-color: #ff1744;
+  --critical-blink-color: #ff4757;
 
   /* Borders */
   --border-subtle: 1px solid #1E293B;
@@ -620,8 +620,9 @@ a:hover { text-decoration: underline; }
 }
 
 .alert-badge--critical {
-  background: rgba(255, 23, 68, 0.12);
+  background: rgba(255, 71, 87, 0.15);
   color: var(--alert-critical);
+  text-shadow: 0 0 8px rgba(255, 71, 87, 0.4);
 }
 
 .alert-badge--warning {

--- a/web/css/overlays.css
+++ b/web/css/overlays.css
@@ -251,9 +251,56 @@
 @keyframes st-dash { to { stroke-dashoffset: -30; } }
 
 /* ════════════════════════════════════════════════════
-   RESPONSIVE — hide panel on mobile
+   MOBILE TOGGLE BUTTON (hidden on desktop)
+   ════════════════════════════════════════════════════ */
+.st-layers-toggle {
+  display: none;
+}
+
+/* ════════════════════════════════════════════════════
+   RESPONSIVE — overlay panel on mobile
    ════════════════════════════════════════════════════ */
 @media (max-width: 768px) {
-  #st-layers { display: none; }
+  .st-layers-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    bottom: 60px;
+    left: 10px;
+    width: 44px;
+    height: 44px;
+    background: var(--st-panel);
+    border: 1px solid var(--st-border-hi);
+    color: var(--st-amber);
+    z-index: 860;
+    cursor: pointer;
+    box-shadow: 0 2px 12px rgba(0,0,0,.5);
+    border-radius: 4px;
+  }
+  .st-layers-toggle:active {
+    background: var(--st-amber-dim);
+  }
+
+  #st-layers {
+    display: none;
+    position: fixed;
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    max-height: 60vh;
+    overflow-y: auto;
+    z-index: 1200;
+    border-radius: 12px 12px 0 0;
+    border: none;
+    border-top: 2px solid var(--st-border-hi);
+    box-shadow: 0 -4px 24px rgba(0,0,0,.7);
+  }
+  #st-layers.mobile-open {
+    display: block;
+  }
+
   #st-card { bottom: 60px; width: 200px; }
 }

--- a/web/css/responsive.css
+++ b/web/css/responsive.css
@@ -240,6 +240,10 @@
     padding: 12px;
     min-height: 44px;
   }
+
+  .search-dropdown {
+    max-height: 200px;
+  }
 }
 
 /* --- Large Desktop: >= 1440px --- */

--- a/web/index.html
+++ b/web/index.html
@@ -37,12 +37,12 @@
       </div>
       <div class="header-center">
         <div style="position:relative">
-          <input type="text" id="search" placeholder="Search country..." autocomplete="off" />
-          <div class="search-dropdown" id="search-dropdown"></div>
+          <input type="text" id="search" placeholder="Search country..." autocomplete="off" aria-label="Search countries" role="combobox" aria-expanded="false" aria-controls="search-dropdown" />
+          <div class="search-dropdown" id="search-dropdown" role="listbox"></div>
         </div>
       </div>
       <div class="header-right">
-        <nav id="main-nav">
+        <nav id="main-nav" aria-label="Main navigation">
           <a href="#map" class="nav-link active" data-view="map">Map</a>
           <a href="#briefing" class="nav-link" data-view="briefing">Stories</a>
           <a href="#alerts" class="nav-link" data-view="alerts">Alerts</a>
@@ -54,7 +54,16 @@
 
     <main id="main-content">
       <div id="map-container"></div>
-      <div id="country-panel" class="panel hidden"></div>
+      <div id="country-panel" class="panel hidden" role="complementary" aria-label="Country detail"></div>
+
+      <!-- Intel Overlays toggle (mobile) -->
+      <button id="st-layers-toggle" class="st-layers-toggle" aria-label="Toggle intel overlays">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="3" width="16" height="3" rx="1" fill="currentColor" opacity="0.9"/>
+          <rect x="2" y="9" width="16" height="3" rx="1" fill="currentColor" opacity="0.6"/>
+          <rect x="2" y="15" width="16" height="3" rx="1" fill="currentColor" opacity="0.35"/>
+        </svg>
+      </button>
 
       <!-- Intel Overlays -->
       <div id="st-layers">
@@ -63,83 +72,83 @@
           <span class="hl-toggle">&blacktriangle;</span>
         </div>
         <div id="st-layers-body">
-          <div class="st-group-head">Air &amp; Maritime</div>
-          <div class="st-row on" data-layer="airports">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-blue)"></div>
-            <span class="st-label">Major Airports</span>
+          <div class="st-group-head" id="group-air">Air &amp; Maritime</div>
+          <div class="st-row on" data-layer="airports" role="switch" aria-checked="true" tabindex="0" aria-labelledby="label-airports">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-blue)" aria-hidden="true"></div>
+            <span class="st-label" id="label-airports">Major Airports</span>
             <span class="st-badge">0</span>
           </div>
-          <div class="st-row on" data-layer="ports">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-teal)"></div>
-            <span class="st-label">Strategic Ports</span>
+          <div class="st-row on" data-layer="ports" role="switch" aria-checked="true" tabindex="0" aria-labelledby="label-ports">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-teal)" aria-hidden="true"></div>
+            <span class="st-label" id="label-ports">Strategic Ports</span>
             <span class="st-badge">0</span>
           </div>
-          <div class="st-row" data-layer="chokepoints">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-orange)"></div>
-            <span class="st-label">Sea Chokepoints</span>
+          <div class="st-row" data-layer="chokepoints" role="switch" aria-checked="false" tabindex="0" aria-labelledby="label-chokepoints">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-orange)" aria-hidden="true"></div>
+            <span class="st-label" id="label-chokepoints">Sea Chokepoints</span>
             <span class="st-badge">0</span>
           </div>
-          <div class="st-row" data-layer="cables">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-purple)"></div>
-            <span class="st-label">Submarine Cables</span>
-            <span class="st-badge">0</span>
-          </div>
-
-          <div class="st-group-head">Military</div>
-          <div class="st-row on" data-layer="bases">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-amber)"></div>
-            <span class="st-label">Military Bases</span>
-            <span class="st-badge">0</span>
-          </div>
-          <div class="st-row on" data-layer="conflicts">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-red)"></div>
-            <span class="st-label">Conflict Zones</span>
-            <span class="st-badge">0</span>
-          </div>
-          <div class="st-row" data-layer="missiles">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-red)"></div>
-            <span class="st-label">Missile Coverage</span>
-            <span class="st-badge">0</span>
-          </div>
-          <div class="st-row" data-layer="nuclear">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-orange)"></div>
-            <span class="st-label">Nuclear Sites</span>
+          <div class="st-row" data-layer="cables" role="switch" aria-checked="false" tabindex="0" aria-labelledby="label-cables">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-purple)" aria-hidden="true"></div>
+            <span class="st-label" id="label-cables">Submarine Cables</span>
             <span class="st-badge">0</span>
           </div>
 
-          <div class="st-group-head">Infrastructure</div>
-          <div class="st-row on" data-layer="power">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-amber)"></div>
-            <span class="st-label">Power Stations</span>
+          <div class="st-group-head" id="group-military">Military</div>
+          <div class="st-row on" data-layer="bases" role="switch" aria-checked="true" tabindex="0" aria-labelledby="label-bases">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-amber)" aria-hidden="true"></div>
+            <span class="st-label" id="label-bases">Military Bases</span>
             <span class="st-badge">0</span>
           </div>
-          <div class="st-row" data-layer="pipelines">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-orange)"></div>
-            <span class="st-label">Oil &amp; Gas Pipelines</span>
+          <div class="st-row on" data-layer="conflicts" role="switch" aria-checked="true" tabindex="0" aria-labelledby="label-conflicts">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-red)" aria-hidden="true"></div>
+            <span class="st-label" id="label-conflicts">Conflict Zones</span>
             <span class="st-badge">0</span>
           </div>
-          <div class="st-row" data-layer="cyber">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-purple)"></div>
-            <span class="st-label">Cyber Operations</span>
+          <div class="st-row" data-layer="missiles" role="switch" aria-checked="false" tabindex="0" aria-labelledby="label-missiles">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-red)" aria-hidden="true"></div>
+            <span class="st-label" id="label-missiles">Missile Coverage</span>
+            <span class="st-badge">0</span>
+          </div>
+          <div class="st-row" data-layer="nuclear" role="switch" aria-checked="false" tabindex="0" aria-labelledby="label-nuclear">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-orange)" aria-hidden="true"></div>
+            <span class="st-label" id="label-nuclear">Nuclear Sites</span>
             <span class="st-badge">0</span>
           </div>
 
-          <div class="st-group-head">Humanitarian</div>
-          <div class="st-row" data-layer="sanctions">
-            <div class="st-pill"></div>
-            <div class="st-swatch" style="background:var(--st-red)"></div>
-            <span class="st-label">Active Sanctions</span>
+          <div class="st-group-head" id="group-infra">Infrastructure</div>
+          <div class="st-row on" data-layer="power" role="switch" aria-checked="true" tabindex="0" aria-labelledby="label-power">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-amber)" aria-hidden="true"></div>
+            <span class="st-label" id="label-power">Power Stations</span>
+            <span class="st-badge">0</span>
+          </div>
+          <div class="st-row" data-layer="pipelines" role="switch" aria-checked="false" tabindex="0" aria-labelledby="label-pipelines">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-orange)" aria-hidden="true"></div>
+            <span class="st-label" id="label-pipelines">Oil &amp; Gas Pipelines</span>
+            <span class="st-badge">0</span>
+          </div>
+          <div class="st-row" data-layer="cyber" role="switch" aria-checked="false" tabindex="0" aria-labelledby="label-cyber">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-purple)" aria-hidden="true"></div>
+            <span class="st-label" id="label-cyber">Cyber Operations</span>
+            <span class="st-badge">0</span>
+          </div>
+
+          <div class="st-group-head" id="group-humanitarian">Humanitarian</div>
+          <div class="st-row" data-layer="sanctions" role="switch" aria-checked="false" tabindex="0" aria-labelledby="label-sanctions">
+            <div class="st-pill" aria-hidden="true"></div>
+            <div class="st-swatch" style="background:var(--st-red)" aria-hidden="true"></div>
+            <span class="st-label" id="label-sanctions">Active Sanctions</span>
             <span class="st-badge">0</span>
           </div>
         </div>
@@ -162,7 +171,7 @@
     <footer id="bottom-bar">
       <div class="metric-selector">
         <label>Color by:</label>
-        <select id="metric-select">
+        <select id="metric-select" aria-label="Color map by metric">
           <option value="alert_severity" selected>Alert Severity</option>
           <option value="gdp_growth_trend">GDP Growth</option>
           <option value="political_stability">Political Stability</option>
@@ -176,7 +185,7 @@
       </div>
       <div class="overlay-selector">
         <label>Overlay:</label>
-        <select id="overlay-select">
+        <select id="overlay-select" aria-label="Geopolitical overlay">
           <option value="none">None</option>
           <option value="EU">EU</option>
           <option value="NATO">NATO</option>
@@ -193,7 +202,7 @@
     </footer>
   </div>
 
-  <div id="alert-ticker" class="alert-ticker hidden">
+  <div id="alert-ticker" class="alert-ticker hidden" role="alert" aria-live="polite">
     <!-- Primary bar: critical / warning alerts, rotates every 30s -->
     <div id="ticker-primary" class="ticker-primary">
       <div class="ticker-tag" id="ticker-tag">

--- a/web/js/country-panel.js
+++ b/web/js/country-panel.js
@@ -9,6 +9,7 @@ var CountryPanel = (function() {
   var activeTab = 'economy';
   var _currentRelationPairs = [];
   var _networkDrawn = false;
+  var _tabScrollPositions = {};
 
   var TAB_DEFS = [
     { id: 'endowments',   label: 'Endowments' },
@@ -922,6 +923,8 @@ var CountryPanel = (function() {
       var btn = e.target.closest('.layer-tab');
       if (!btn || btn.classList.contains('disabled')) return;
       var tabId = btn.getAttribute('data-tab');
+      // Save scroll position of current tab
+      _tabScrollPositions[activeTab] = panelEl.scrollTop;
       activeTab = tabId;
       // Update active states
       tabsEl.querySelectorAll('.layer-tab').forEach(function(t) { t.classList.remove('active'); });
@@ -929,6 +932,10 @@ var CountryPanel = (function() {
       panelEl.querySelectorAll('.layer-content').forEach(function(c) { c.classList.remove('active'); });
       var content = document.getElementById('tab-' + tabId);
       if (content) content.classList.add('active');
+      // Restore scroll position for this tab
+      if (_tabScrollPositions[tabId] != null) {
+        panelEl.scrollTop = _tabScrollPositions[tabId];
+      }
       // Draw D3 network when Relations tab is first activated
       if (tabId === 'relations' && !_networkDrawn) {
         requestAnimationFrame(function() { drawRelationsNetwork(); });
@@ -968,6 +975,7 @@ var CountryPanel = (function() {
       activeTab = 'economy';
       _currentRelationPairs = [];
       _networkDrawn = false;
+      _tabScrollPositions = {};
 
       // Show panel
       panelEl.classList.remove('hidden');

--- a/web/js/data-loader.js
+++ b/web/js/data-loader.js
@@ -32,18 +32,30 @@ var DataLoader = (function() {
     return dataPath('chunks/' + relativePath);
   }
 
-  async function fetchJSON(path) {
+  function wait(ms) { return new Promise(function(r) { setTimeout(r, ms); }); }
+
+  async function fetchJSON(path, retries) {
     if (cache[path]) return cache[path];
-    try {
-      var response = await fetch(path);
-      if (!response.ok) throw new Error('HTTP ' + response.status + ' loading ' + path);
-      var data = await response.json();
-      cache[path] = data;
-      return data;
-    } catch (err) {
-      console.error('[DataLoader] Failed to load:', path, err.message);
-      throw err;
+    retries = retries != null ? retries : 3;
+    var lastErr;
+    for (var attempt = 0; attempt <= retries; attempt++) {
+      try {
+        var response = await fetch(path);
+        if (!response.ok) throw new Error('HTTP ' + response.status + ' loading ' + path);
+        var data = await response.json();
+        cache[path] = data;
+        return data;
+      } catch (err) {
+        lastErr = err;
+        if (attempt < retries) {
+          var delay = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s
+          console.warn('[DataLoader] Retry ' + (attempt + 1) + '/' + retries + ' for:', path, '(' + delay + 'ms)');
+          await wait(delay);
+        }
+      }
     }
+    console.error('[DataLoader] Failed to load after ' + retries + ' retries:', path, lastErr.message);
+    throw lastErr;
   }
 
   return {

--- a/web/js/map-view.js
+++ b/web/js/map-view.js
@@ -263,7 +263,18 @@ var MapView = (function() {
     getMap() { return map; },
 
     invalidateSize() {
-      if (map) setTimeout(function() { map.invalidateSize(); }, 300);
+      if (!map) return;
+      // Use ResizeObserver for reliable layout-driven resize, with setTimeout fallback
+      var container = map.getContainer();
+      if (window.ResizeObserver && container) {
+        var ro = new ResizeObserver(function() {
+          map.invalidateSize();
+          ro.disconnect();
+        });
+        ro.observe(container);
+      } else {
+        setTimeout(function() { map.invalidateSize(); }, 300);
+      }
     }
   };
 })();

--- a/web/js/overlays.js
+++ b/web/js/overlays.js
@@ -294,10 +294,23 @@ var IntelOverlays = (function() {
         LG[id].addTo(map);
       }
 
+      function toggleLayer() {
+        var on = row.classList.toggle('on');
+        row.setAttribute('aria-checked', on ? 'true' : 'false');
+        if (on) { LG[id].addTo(map); } else { LG[id].remove(); }
+      }
+
       row.addEventListener('click', function(e) {
         e.stopPropagation();
-        var on = row.classList.toggle('on');
-        if (on) { LG[id].addTo(map); } else { LG[id].remove(); }
+        toggleLayer();
+      });
+
+      row.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          e.stopPropagation();
+          toggleLayer();
+        }
       });
     });
 
@@ -317,8 +330,20 @@ var IntelOverlays = (function() {
       closeBtn.addEventListener('click', function() { hideCard(); });
     }
 
-    // Click map to close card
-    map.on('click', function() { hideCard(); });
+    // Click map to close card and mobile overlay panel
+    map.on('click', function() {
+      hideCard();
+      if (panelEl) panelEl.classList.remove('mobile-open');
+    });
+
+    // Mobile toggle button
+    var toggleBtn = document.getElementById('st-layers-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        if (panelEl) panelEl.classList.toggle('mobile-open');
+      });
+    }
   }
 
   /* ── Public API ──────────────────────────────────────────── */
@@ -338,7 +363,10 @@ var IntelOverlays = (function() {
         LG[id] = L.layerGroup();
       });
 
-      // Fetch all layers
+      // Wire panel immediately so badge counts update as layers load
+      wirePanel();
+
+      // Fetch all layers (badges update as each layer resolves)
       var promises = LAYER_IDS.map(function(id) {
         return fetchLayer(id).catch(function(err) {
           console.warn('[IntelOverlays] Failed to load layer:', id, err);
@@ -346,11 +374,11 @@ var IntelOverlays = (function() {
       });
 
       return Promise.allSettled
-        ? Promise.allSettled(promises).then(function() { wirePanel(); initialized = true; })
+        ? Promise.allSettled(promises).then(function() { initialized = true; })
         : Promise.all(promises.map(function(p) {
             return p.then(function(v) { return {status:'fulfilled',value:v}; },
                           function(e) { return {status:'rejected',reason:e}; });
-          })).then(function() { wirePanel(); initialized = true; });
+          })).then(function() { initialized = true; });
     },
 
     show: function() {


### PR DESCRIPTION
- Fix overlay badge counts updating at init (wirePanel before fetch completes)
- Add retry with exponential backoff (3 attempts) to DataLoader fetch
- Replace map invalidateSize setTimeout with ResizeObserver
- Preserve scroll position when switching country panel tabs
- Add mobile toggle button for Intel Overlays panel (bottom-sheet drawer)
- Reduce search dropdown max-height on mobile to prevent overflow
- Add ARIA labels, roles, and keyboard navigation to overlay toggles
- Improve alert color contrast (#ff1744 -> #ff4757) with text-shadow
- Add aria-live to alert ticker, aria-label to search/selectors

https://claude.ai/code/session_01S6PUxzZxXpUtkDzCTW6Lzt