### PR TITLE
Add mobile-first layout: bottom tab bar, map toolbar, ticker fix

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -258,6 +258,10 @@ a:hover { text-decoration: underline; }
   display: none;
 }
 
+.force-hidden {
+  display: none !important;
+}
+
 /* --- Bottom Bar / Footer --- */
 #bottom-bar {
   display: flex;

--- a/web/css/overlays.css
+++ b/web/css/overlays.css
@@ -260,23 +260,24 @@
 /* ════════════════════════════════════════════════════
    RESPONSIVE — overlay panel on mobile
    ════════════════════════════════════════════════════ */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .st-layers-toggle {
     display: flex;
     align-items: center;
     justify-content: center;
     position: absolute;
-    bottom: 60px;
-    left: 10px;
-    width: 44px;
-    height: 44px;
-    background: var(--st-panel);
+    bottom: 8px;
+    left: 8px;
+    width: 40px;
+    height: 40px;
+    background: rgba(11, 14, 20, 0.92);
     border: 1px solid var(--st-border-hi);
     color: var(--st-amber);
     z-index: 860;
     cursor: pointer;
     box-shadow: 0 2px 12px rgba(0,0,0,.5);
-    border-radius: 4px;
+    border-radius: 6px;
+    -webkit-tap-highlight-color: transparent;
   }
   .st-layers-toggle:active {
     background: var(--st-amber-dim);
@@ -286,11 +287,11 @@
     display: none;
     position: fixed;
     top: auto;
-    bottom: 0;
+    bottom: var(--mobile-tab-bar-height, 56px);
     left: 0;
     right: 0;
     width: 100%;
-    max-height: 60vh;
+    max-height: 55vh;
     overflow-y: auto;
     z-index: 1200;
     border-radius: 12px 12px 0 0;
@@ -302,5 +303,11 @@
     display: block;
   }
 
-  #st-card { bottom: 60px; width: 200px; }
+  #st-card {
+    position: fixed;
+    bottom: calc(var(--mobile-tab-bar-height, 56px) + 8px);
+    left: 8px;
+    right: 8px;
+    width: auto;
+  }
 }

--- a/web/css/responsive.css
+++ b/web/css/responsive.css
@@ -47,8 +47,24 @@
 }
 
 /* --- Mobile: < 768px --- */
+
+/* Mobile tab bar height variable */
+:root {
+  --mobile-tab-bar-height: 56px;
+}
+
+/* Mobile tab bar — hidden on desktop */
+.mobile-tab-bar {
+  display: none;
+}
+
+/* Mobile map toolbar — hidden on desktop */
+.mobile-map-toolbar {
+  display: none;
+}
+
 @media (max-width: 767px) {
-  /* Header compact */
+  /* Header compact — logo + search only */
   #header {
     flex-wrap: wrap;
     height: auto;
@@ -74,56 +90,47 @@
     margin-left: auto;
   }
 
-  /* Bottom tab navigation */
+  /* Hide desktop nav on mobile */
   #main-nav {
     display: none;
   }
 
+  /* Hide desktop bottom bar on mobile (replaced by mobile toolbar) */
   #bottom-bar {
-    flex-wrap: wrap;
-    height: auto;
-    padding: 6px 8px;
-    gap: 4px;
+    display: none;
   }
 
-  .metric-selector,
-  .overlay-selector {
-    flex: 1 1 45%;
-  }
-
-  .last-updated {
-    flex: 1 1 100%;
-    text-align: center;
-    padding-top: 4px;
-  }
-
-  /* Mobile bottom tab bar */
+  /* ── Mobile bottom tab bar ── */
   .mobile-tab-bar {
     display: flex;
     position: fixed;
     bottom: 0;
     left: 0;
     right: 0;
+    height: var(--mobile-tab-bar-height);
     background: var(--bg-secondary);
-    border-top: var(--border-subtle);
+    border-top: 1px solid rgba(255,255,255,0.08);
     z-index: 1100;
-    padding: 4px 0;
+    padding: 0;
     justify-content: space-around;
+    align-items: stretch;
   }
 
   .mobile-tab {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 6px 4px;
+    justify-content: center;
+    flex: 1;
+    padding: 4px 0;
     background: none;
     border: none;
     color: var(--text-muted);
     font-size: 10px;
+    font-family: var(--font-ui);
     cursor: pointer;
-    min-width: 44px;
-    min-height: 44px;
-    justify-content: center;
+    -webkit-tap-highlight-color: transparent;
+    transition: color 0.15s;
   }
 
   .mobile-tab.active {
@@ -131,11 +138,82 @@
   }
 
   .mobile-tab__icon {
-    font-size: 18px;
-    margin-bottom: 2px;
+    font-size: 20px;
+    line-height: 1;
+    margin-bottom: 3px;
   }
 
-  /* Full-screen panel on mobile */
+  /* ── Mobile map toolbar (Color by + Overlay) ── */
+  .mobile-map-toolbar {
+    display: flex;
+    position: absolute;
+    bottom: 8px;
+    left: 54px;
+    right: 8px;
+    gap: 6px;
+    z-index: 860;
+  }
+
+  .mobile-map-toolbar select {
+    flex: 1;
+    height: 36px;
+    padding: 0 8px;
+    background: rgba(11, 14, 20, 0.92);
+    color: var(--text-primary);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 6px;
+    font-size: 12px;
+    font-family: var(--font-ui);
+    -webkit-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%2394A3B8'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+    padding-right: 24px;
+  }
+
+  /* ── Main content area — leave room for tab bar ── */
+  #app {
+    padding-bottom: var(--mobile-tab-bar-height);
+  }
+
+  /* ── Alert ticker — position above tab bar ── */
+  .alert-ticker {
+    bottom: var(--mobile-tab-bar-height) !important;
+  }
+
+  .ticker-primary {
+    height: 36px;
+  }
+
+  .ticker-headline {
+    font-size: 11px !important;
+  }
+
+  .ticker-tag__label {
+    font-size: 9px !important;
+  }
+
+  .ticker-secondary {
+    height: 22px;
+  }
+
+  .ticker-scroll-item {
+    font-size: 10px !important;
+  }
+
+  /* Adjust main-content margin for ticker on mobile */
+  #app.ticker-watch-on #main-content              { margin-bottom: 22px; }
+  #app.ticker-primary-on #main-content            { margin-bottom: 36px; }
+  #app.ticker-watch-on.ticker-primary-on #main-content { margin-bottom: 58px; }
+
+  /* ── View containers — full screen above tab bar ── */
+  .view-container {
+    padding: 16px 12px;
+    padding-bottom: 24px;
+  }
+
+  /* ── Full-screen panel on mobile ── */
   .panel {
     width: 100%;
     max-width: 100%;
@@ -148,7 +226,7 @@
     flex: 1;
   }
 
-  /* Factor grid single column */
+  /* ── Factor grid single column ── */
   .factor-grid {
     grid-template-columns: 1fr;
   }
@@ -161,11 +239,6 @@
   .layer-tab {
     padding: 8px 10px;
     font-size: 11px;
-  }
-
-  /* View containers full width */
-  .view-container {
-    padding: 12px 8px;
   }
 
   /* Rankings as cards on mobile */
@@ -208,21 +281,19 @@
     min-width: 60px;
   }
 
-  /* Disclaimer */
+  /* Disclaimer — above tab bar */
   #disclaimer {
     font-size: 10px;
     padding: 3px 8px;
+    bottom: var(--mobile-tab-bar-height) !important;
   }
 
   /* Ensure touch targets >= 44px */
-  .nav-link,
   .layer-tab,
   .region-tab,
   .panel-header__back,
   .panel-header__close,
   .alert-filter-select,
-  #metric-select,
-  #overlay-select,
   .reasoning-toggle,
   .source-toggle {
     min-height: 44px;

--- a/web/index.html
+++ b/web/index.html
@@ -56,6 +56,31 @@
       <div id="map-container"></div>
       <div id="country-panel" class="panel hidden" role="complementary" aria-label="Country detail"></div>
 
+      <!-- Mobile map toolbar (Color by + Overlay, visible only on mobile map view) -->
+      <div id="mobile-map-toolbar" class="mobile-map-toolbar">
+        <select id="mobile-metric-select" aria-label="Color map by metric">
+          <option value="alert_severity" selected>Alert Severity</option>
+          <option value="gdp_growth_trend">GDP Growth</option>
+          <option value="political_stability">Stability</option>
+          <option value="investment_risk">Inv. Risk</option>
+          <option value="military_spending_trend">Mil. Spend</option>
+          <option value="military_spending_pct_gdp">Mil. % GDP</option>
+          <option value="composite_power">Power Index</option>
+          <option value="energy_independence">Energy Ind.</option>
+          <option value="trade_openness">Trade Open.</option>
+        </select>
+        <select id="mobile-overlay-select" aria-label="Geopolitical overlay">
+          <option value="none">No Overlay</option>
+          <option value="EU">EU</option>
+          <option value="NATO">NATO</option>
+          <option value="BRICS">BRICS</option>
+          <option value="ASEAN">ASEAN</option>
+          <option value="OPEC">OPEC</option>
+          <option value="G7">G7</option>
+          <option value="G20">G20</option>
+        </select>
+      </div>
+
       <!-- Intel Overlays toggle (mobile) -->
       <button id="st-layers-toggle" class="st-layers-toggle" aria-label="Toggle intel overlays">
         <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -222,6 +247,30 @@
       </div>
     </div>
   </div>
+
+  <!-- Mobile bottom tab bar (hidden on desktop) -->
+  <nav id="mobile-tab-bar" class="mobile-tab-bar" aria-label="Mobile navigation">
+    <button class="mobile-tab active" data-view="map">
+      <span class="mobile-tab__icon">&#x1F5FA;</span>
+      <span>Map</span>
+    </button>
+    <button class="mobile-tab" data-view="briefing">
+      <span class="mobile-tab__icon">&#x1F4F0;</span>
+      <span>Stories</span>
+    </button>
+    <button class="mobile-tab" data-view="alerts">
+      <span class="mobile-tab__icon">&#x26A0;</span>
+      <span>Alerts</span>
+    </button>
+    <button class="mobile-tab" data-view="rankings">
+      <span class="mobile-tab__icon">&#x1F3C6;</span>
+      <span>Rankings</span>
+    </button>
+    <button class="mobile-tab" data-view="compare">
+      <span class="mobile-tab__icon">&#x2194;</span>
+      <span>Compare</span>
+    </button>
+  </nav>
 
   <div id="disclaimer">
     AI-generated geopolitical analysis for informational purposes only.

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -218,12 +218,12 @@
 
     if (viewName === 'map') {
       mapContainer.style.display = '';
-      bottomBar.style.display = '';
+      bottomBar.classList.remove('force-hidden');
       if (MapView.getMap()) MapView.getMap().invalidateSize();
       IntelOverlays.show();
     } else {
       mapContainer.style.display = 'none';
-      bottomBar.style.display = 'none';
+      bottomBar.classList.add('force-hidden');
       IntelOverlays.hide();
       // Close panels when leaving map
       if (CountryPanel.isOpen()) CountryPanel.close();
@@ -246,10 +246,25 @@
       AlertTicker.show();
     }
 
-    // Update nav active state
+    // Update nav active state (desktop + mobile)
     document.querySelectorAll('.nav-link').forEach(function(link) {
       link.classList.toggle('active', link.getAttribute('data-view') === viewName);
     });
+    document.querySelectorAll('.mobile-tab').forEach(function(tab) {
+      tab.classList.toggle('active', tab.getAttribute('data-view') === viewName);
+    });
+
+    // Show/hide mobile map toolbar
+    var mobileToolbar = document.getElementById('mobile-map-toolbar');
+    if (mobileToolbar) {
+      mobileToolbar.style.display = viewName === 'map' ? '' : 'none';
+    }
+
+    // Show/hide mobile overlay toggle
+    var layersToggle = document.getElementById('st-layers-toggle');
+    if (layersToggle) {
+      layersToggle.style.display = viewName === 'map' ? '' : 'none';
+    }
 
     currentView = viewName;
   }
@@ -309,19 +324,53 @@
       }
     );
 
-    // Wire metric selector
+    // Wire metric selector (desktop)
     var metricSelect = document.getElementById('metric-select');
     if (metricSelect) {
       metricSelect.addEventListener('change', function() {
         MapView.setMetric(this.value);
+        // Sync mobile selector
+        var mob = document.getElementById('mobile-metric-select');
+        if (mob) mob.value = this.value;
       });
     }
 
-    // Wire overlay selector
+    // Wire overlay selector (desktop)
     var overlaySelect = document.getElementById('overlay-select');
     if (overlaySelect) {
       overlaySelect.addEventListener('change', function() {
         MapView.setOverlay(this.value);
+        // Sync mobile selector
+        var mob = document.getElementById('mobile-overlay-select');
+        if (mob) mob.value = this.value;
+      });
+    }
+
+    // Wire mobile tab bar
+    document.querySelectorAll('.mobile-tab').forEach(function(tab) {
+      tab.addEventListener('click', function() {
+        var view = tab.getAttribute('data-view');
+        window.location.hash = '#' + view;
+      });
+    });
+
+    // Wire mobile metric selector (synced with desktop)
+    var mobileMetricSelect = document.getElementById('mobile-metric-select');
+    if (mobileMetricSelect) {
+      mobileMetricSelect.addEventListener('change', function() {
+        MapView.setMetric(this.value);
+        // Sync desktop selector
+        if (metricSelect) metricSelect.value = this.value;
+      });
+    }
+
+    // Wire mobile overlay selector (synced with desktop)
+    var mobileOverlaySelect = document.getElementById('mobile-overlay-select');
+    if (mobileOverlaySelect) {
+      mobileOverlaySelect.addEventListener('change', function() {
+        MapView.setOverlay(this.value);
+        // Sync desktop selector
+        if (overlaySelect) overlaySelect.value = this.value;
       });
     }
 

--- a/web/js/overlays.js
+++ b/web/js/overlays.js
@@ -391,7 +391,10 @@ var IntelOverlays = (function() {
         cardEl.dataset.wasOpen = cardEl.style.display === 'block' ? 'true' : 'false';
         cardEl.style.display = 'none';
       }
-      if (panelEl) panelEl.style.display = 'none';
+      if (panelEl) {
+        panelEl.style.display = 'none';
+        panelEl.classList.remove('mobile-open');
+      }
     }
   };
 })();


### PR DESCRIPTION
Mobile (< 768px) was missing navigation, map controls, and had overlapping elements. This commit adds a complete mobile layout:

- Add bottom tab bar (Map, Stories, Alerts, Rankings, Compare) with icons, replacing the hidden desktop nav
- Add floating map toolbar with compact Color-by and Overlay selectors, synced bidirectionally with desktop selectors
- Hide desktop #bottom-bar on mobile to avoid layout conflict
- Fix alert ticker position: sits above mobile tab bar (56px) with smaller font sizes for compact display
- Fix Intel Overlays panel: bottom-sheet sits above tab bar, toggle button repositioned next to map toolbar
- Add padding-bottom to #app so content doesn't hide behind tab bar
- Fix disclaimer position above tab bar on mobile
- Properly hide mobile-only elements on desktop (display: none)
- Clean mobile-open state when switching away from map view

https://claude.ai/code/session_01S6PUxzZxXpUtkDzCTW6Lzt