### PR TITLE
Fix mobile map controls hidden behind ticker/tab bar

### DIFF
--- a/web/css/overlays.css
+++ b/web/css/overlays.css
@@ -265,15 +265,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    position: absolute;
-    bottom: 8px;
+    position: fixed;
+    bottom: calc(var(--mobile-tab-bar-height) + 8px);
     left: 8px;
     width: 40px;
     height: 40px;
     background: rgba(11, 14, 20, 0.92);
     border: 1px solid var(--st-border-hi);
     color: var(--st-amber);
-    z-index: 860;
+    z-index: 1050;
     cursor: pointer;
     box-shadow: 0 2px 12px rgba(0,0,0,.5);
     border-radius: 6px;

--- a/web/css/responsive.css
+++ b/web/css/responsive.css
@@ -146,12 +146,12 @@
   /* ── Mobile map toolbar (Color by + Overlay) ── */
   .mobile-map-toolbar {
     display: flex;
-    position: absolute;
-    bottom: 8px;
+    position: fixed;
+    bottom: calc(var(--mobile-tab-bar-height) + 8px);
     left: 54px;
     right: 8px;
     gap: 6px;
-    z-index: 860;
+    z-index: 1050;
   }
 
   .mobile-map-toolbar select {
@@ -206,6 +206,31 @@
   #app.ticker-watch-on #main-content              { margin-bottom: 22px; }
   #app.ticker-primary-on #main-content            { margin-bottom: 36px; }
   #app.ticker-watch-on.ticker-primary-on #main-content { margin-bottom: 58px; }
+
+  /* Shift map controls up when ticker bars are visible */
+  #app.ticker-watch-on .mobile-map-toolbar,
+  #app.ticker-watch-on .st-layers-toggle {
+    bottom: calc(var(--mobile-tab-bar-height) + 22px + 8px);
+  }
+  #app.ticker-primary-on .mobile-map-toolbar,
+  #app.ticker-primary-on .st-layers-toggle {
+    bottom: calc(var(--mobile-tab-bar-height) + 36px + 8px);
+  }
+  #app.ticker-watch-on.ticker-primary-on .mobile-map-toolbar,
+  #app.ticker-watch-on.ticker-primary-on .st-layers-toggle {
+    bottom: calc(var(--mobile-tab-bar-height) + 58px + 8px);
+  }
+
+  /* Smooth transition for controls repositioning */
+  .mobile-map-toolbar,
+  .st-layers-toggle {
+    transition: bottom 0.2s ease;
+  }
+
+  /* ── Color legend — above toolbar controls ── */
+  .color-legend {
+    bottom: 52px !important;
+  }
 
   /* ── View containers — full screen above tab bar ── */
   .view-container {


### PR DESCRIPTION
Change Color-by, Overlay selects and Intel Overlays toggle from position:absolute to position:fixed, anchored above the tab bar. Add ticker-aware bottom offsets so controls shift up when alert ticker bars are active. Bump z-index to 1050 to stay above other map UI. Add smooth transition on bottom repositioning.

https://claude.ai/code/session_01S6PUxzZxXpUtkDzCTW6Lzt